### PR TITLE
Added permanent bannerleadership to ivory tower with double radius

### DIFF
--- a/data/ini/object/goodfaction/structures/men/fortress.ini
+++ b/data/ini/object/goodfaction/structures/men/fortress.ini
@@ -940,6 +940,17 @@ Object MenFortressCitadel
 		TriggeredBy			= Upgrade_MenFortressIvoryTower Upgrade_MenFortressNumenorStonework
 		RequiresAllTriggers = Yes
 	End	
+
+	// Ivory Tower improvement, a leadership permanent aura bonus
+	Behavior = AttributeModifierAuraUpdate ModuleTag_IvoryTowerLeadership
+		StartsActive	= No ;If no, requires upgrade to turn on.
+		BonusName		= MenFortressBannersLeadership
+		TriggeredBy		= Upgrade_MenFortressIvoryTower Upgrade_MenFortressNumenorStonework
+		RequiresAllTriggers = Yes
+		RefreshDelay	= 2000
+		Range			= 600
+		ObjectFilter	= GENERIC_BUFF_RECIPIENT_OBJECT_FILTER
+	End	
 	
 	Behavior = GeometryUpgrade TowerGeom
 		TriggeredBy			= Upgrade_MenFortressIvoryTower Upgrade_MenFortressNumenorStonework


### PR DESCRIPTION
This PR solves https://github.com/SymoniusGit/TROWMod/issues/15

With double radius (600 instead of 300).

The screenshot below shows the difference between the two distances to the fortress. The first group of archers is in the 300 radius limit and the second in the 600 radius limit.

![image](https://github.com/user-attachments/assets/9b66ec6a-c7f4-4327-97ec-30da225551be)
